### PR TITLE
Add PSUV party metadata for Venezuela 2025 dataset

### DIFF
--- a/data/ve/2025/data.json
+++ b/data/ve/2025/data.json
@@ -633,5 +633,13 @@
         }
       ]
     }
-  ]
+  ],
+  "parties": {
+    "PSUV": {
+      "name": "Partido Socialista Unido de Venezuela",
+      "en": "United Socialist Party of Venezuela",
+      "range": 1,
+      "color": "#EE1C25"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a parties map entry for PSUV to the Venezuela 2025 data file with localized names and branding info

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d407c9b37c83319d8723a5b799903b