### PR TITLE
Add Colombian Chamber leadership to 2025 dataset

### DIFF
--- a/data/co/2025/data.json
+++ b/data/co/2025/data.json
@@ -102,10 +102,30 @@
       "salary": { "gross": null, "net": null }
     }
   ],
-  "legislature": {
-    "senate": [],
-    "house": []
-  },
+  "deputies": [
+    {
+      "name": "Juan Carlos Wills Ospina",
+      "gender": "M",
+      "party": "PC",
+      "district": "Bogotá D.C.",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Wilmer Carrillo Mendoza",
+      "gender": "M",
+      "party": "PU",
+      "district": "Norte de Santander",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Martha Alfonso Jurado",
+      "gender": "F",
+      "party": "AV",
+      "district": "Tolima",
+      "salary": { "gross": null, "net": null }
+    }
+  ],
+  "senate": [],
   "officials": [
     {
       "name": "Luz Adriana Camargo",
@@ -138,6 +158,24 @@
       "en": "Independent",
       "range": 4,
       "color": "#666666"
+    },
+    "PC": {
+      "name": "Partido Conservador Colombiano",
+      "en": "Colombian Conservative Party",
+      "range": 4,
+      "color": "#0033A0"
+    },
+    "PU": {
+      "name": "Partido de la U",
+      "en": "Social Party of National Unity",
+      "range": 3,
+      "color": "#F6A800"
+    },
+    "AV": {
+      "name": "Partido Alianza Verde",
+      "en": "Green Alliance Party",
+      "range": 2,
+      "color": "#6CC24A"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the 2024-2025 leadership of the Cámara de Representantes to Colombia's 2025 data file
- register the Conservative, Party of the U, and Green Alliance entries in the party map so the new deputies resolve correctly

## Testing
- not run (data change only)


------
https://chatgpt.com/codex/tasks/task_e_68e376f4d25883318ad9360f186b99ee