### PR TITLE
Refactor OpenAPI parameters and tighten year validation

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.1.0
 info:
   title: Government salary API
   version: 1.3.0
+  description: Public JSON datasets for government officials and salary-related analytics by country and year.
 
 tags:
   - name: Country
@@ -13,21 +14,8 @@ paths:
       tags: [Country]
       summary: Get data by country and year
       parameters:
-        - name: code
-          in: path
-          required: true
-          description: ISO country code (alpha-2).
-          schema:
-            type: string
-            pattern: "^[A-Za-z]{2}$"
-            example: us
-        - name: year
-          in: path
-          required: true
-          description: Calendar year of the data.
-          schema:
-            type: integer
-            example: 2025
+        - $ref: "#/components/parameters/CountryCodePathParam"
+        - $ref: "#/components/parameters/YearPathParam"
       responses:
         "200":
           description: OK
@@ -50,21 +38,8 @@ paths:
       tags: [Country]
       summary: Get macroeconomic indicators by country and year
       parameters:
-        - name: code
-          in: path
-          required: true
-          description: ISO country code (alpha-2).
-          schema:
-            type: string
-            pattern: "^[A-Za-z]{2}$"
-            example: us
-        - name: year
-          in: path
-          required: true
-          description: Calendar year of the data.
-          schema:
-            type: integer
-            example: 2025
+        - $ref: "#/components/parameters/CountryCodePathParam"
+        - $ref: "#/components/parameters/YearPathParam"
       responses:
         "200":
           description: OK
@@ -87,14 +62,7 @@ paths:
       tags: [Country]
       summary: Get list of available years for a country
       parameters:
-        - name: code
-          in: path
-          required: true
-          description: ISO country code (alpha-2).
-          schema:
-            type: string
-            pattern: "^[A-Za-z]{2}$"
-            example: us
+        - $ref: "#/components/parameters/CountryCodePathParam"
       responses:
         "200":
           description: OK
@@ -138,13 +106,7 @@ paths:
       tags: [World]
       summary: Get full countries data by year
       parameters:
-        - name: year
-          in: path
-          required: true
-          description: Calendar year of the data.
-          schema:
-            type: integer
-            example: 2025
+        - $ref: "#/components/parameters/YearPathParam"
       responses:
         "200":
           description: OK
@@ -160,13 +122,7 @@ paths:
       tags: [World]
       summary: Get world rates by year
       parameters:
-        - name: year
-          in: path
-          required: true
-          description: Calendar year of the data.
-          schema:
-            type: integer
-            example: 2025
+        - $ref: "#/components/parameters/YearPathParam"
       responses:
         "200":
           description: Successful response
@@ -178,6 +134,26 @@ paths:
           description: Not Found
 
 components:
+  parameters:
+    CountryCodePathParam:
+      name: code
+      in: path
+      required: true
+      description: ISO 3166-1 alpha-2 country code.
+      schema:
+        type: string
+        pattern: "^[A-Za-z]{2}$"
+        example: us
+    YearPathParam:
+      name: year
+      in: path
+      required: true
+      description: Calendar year of the data snapshot.
+      schema:
+        type: integer
+        minimum: 1900
+        maximum: 2100
+        example: 2025
   schemas:
     PartyRange:
       type: integer


### PR DESCRIPTION
### Motivation
- Reduce duplication and improve consistency by centralizing repeated path parameter definitions for country code and year.  
- Make the API self-documenting by adding a concise `info.description`.  
- Harden input validation for year values to avoid out-of-range requests.

### Description
- Added `info.description` to `openapi/openapi.yaml` to clarify the API dataset scope.  
- Introduced reusable path parameters under `components.parameters` (`CountryCodePathParam` and `YearPathParam`) and removed duplicated inline parameter blocks.  
- Replaced inline `code` and `year` path parameters with `$ref` to the shared components in all affected endpoints (`/data/{code}/{year}/data.json`, `/data/{code}/{year}/economics.json`, `/data/{code}/index.json`, `/data/world/{year}/data.json`, `/data/world/{year}/rates.json`).  
- Tightened the `year` schema to include `minimum: 1900` and `maximum: 2100` and improved parameter descriptions.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('openapi/openapi.yaml'); puts 'yaml ok'"` and the file parsed successfully.  
- Attempted `python` YAML load with `yaml.safe_load` but it failed due to missing `pyyaml` (`ModuleNotFoundError`).  
- Attempted `npx -y @redocly/cli lint openapi/openapi.yaml` but the npm package fetch was blocked by the environment (HTTP 403), so the linter could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c99ffd2c8331a1d2f9b44bfd013c)