### PR TITLE
Update Kazakhstan 2026 roster, roles and party metadata; refresh aggregated stats

### DIFF
--- a/data/kz/2026/data.json
+++ b/data/kz/2026/data.json
@@ -18,14 +18,14 @@
   ],
   "ministers": [
     {
-      "name": "Murat Nurtleu",
+      "name": "Yermek Kosherbayev",
       "gender": "M",
-      "role": "Deputy Prime Minister and Minister of Foreign Affairs",
+      "role": "Minister of Foreign Affairs",
       "party": "AMN",
       "salary": { "gross": null, "net": null }
     },
     {
-      "name": "Ruslan Zhaksylykov",
+      "name": "Dauren Kosanov",
       "gender": "M",
       "role": "Minister of Defence",
       "party": "AMN",
@@ -39,21 +39,21 @@
       "salary": { "gross": null, "net": null }
     },
     {
-      "name": "Nurlan Baibazarov",
+      "name": "Serik Zhumangarin",
       "gender": "M",
-      "role": "Minister of National Economy",
+      "role": "Deputy Prime Minister and Minister of National Economy",
       "party": "AMN",
       "salary": { "gross": null, "net": null }
     },
     {
-      "name": "Bagdat Musin",
+      "name": "Zhaslan Madiyev",
       "gender": "M",
-      "role": "Minister of Digital Development, Innovations and Aerospace Industry",
+      "role": "Deputy Prime Minister and Minister of Artificial Intelligence and Digital Development",
       "party": "AMN",
       "salary": { "gross": null, "net": null }
     },
     {
-      "name": "Tamara Duissenova",
+      "name": "Svetlana Zhakupova",
       "gender": "F",
       "role": "Minister of Labour and Social Protection of the Population",
       "party": "AMN",
@@ -65,29 +65,41 @@
       "name": "Erlan Koshanov",
       "gender": "M",
       "party": "AMN",
-      "district": "Karaganda Region",
       "role": "Chairman of the Mazhilis",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Albert Rau",
+      "gender": "M",
+      "party": "AMN",
+      "role": "Deputy Chairman of the Mazhilis",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Daniya Espayeva",
+      "gender": "F",
+      "party": "AKZ",
+      "role": "Deputy Chairwoman of the Mazhilis",
       "salary": { "gross": null, "net": null }
     },
     {
       "name": "Azat Peruashev",
       "gender": "M",
       "party": "AKZ",
-      "district": "Astana",
+      "role": "Leader of the Ak Zhol parliamentary faction",
       "salary": { "gross": null, "net": null }
     },
     {
       "name": "Aidos Sarym",
       "gender": "M",
       "party": "AMN",
-      "district": "Almaty",
       "salary": { "gross": null, "net": null }
     },
     {
-      "name": "Zhambyl Akhmetbekov",
+      "name": "Magerram Magerramov",
       "gender": "M",
       "party": "KNP",
-      "district": "Kostanay Region",
+      "role": "Leader of the People's Party parliamentary faction",
       "salary": { "gross": null, "net": null }
     }
   ],
@@ -96,7 +108,6 @@
       "name": "Maulen Ashimbayev",
       "gender": "M",
       "party": "IND",
-      "district": "Astana",
       "role": "Chairman of the Senate",
       "salary": { "gross": null, "net": null }
     },
@@ -112,7 +123,42 @@
       "name": "Zhakip Asanov",
       "gender": "M",
       "party": "IND",
-      "district": "Atyrau Region",
+      "role": "Deputy Chairman of the Senate",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Nurlan Beknazarov",
+      "gender": "M",
+      "party": "IND",
+      "district": "Shymkent",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Galiaskar Sarybayev",
+      "gender": "M",
+      "party": "IND",
+      "district": "Zhetysu Region",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Ruslan Rustemov",
+      "gender": "M",
+      "party": "IND",
+      "district": "Kyzylorda Region",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Shakarym Bukutgutov",
+      "gender": "M",
+      "party": "IND",
+      "district": "Abai Region",
+      "salary": { "gross": null, "net": null }
+    },
+    {
+      "name": "Alisher Satvaldiyev",
+      "gender": "M",
+      "party": "IND",
+      "district": "Turkistan Region",
       "salary": { "gross": null, "net": null }
     }
   ],
@@ -131,7 +177,7 @@
       "color": "#4BB4E6"
     },
     "KNP": {
-      "name": "Коммунистік халық партиясы",
+      "name": "Қазақстан Халық партиясы",
       "en": "People's Party of Kazakhstan",
       "range": 3,
       "color": "#CC0000"

--- a/data/world/2026/data.json
+++ b/data/world/2026/data.json
@@ -6631,24 +6631,24 @@
       "budget": 0
     },
     "deputies": {
-      "quantity": 4
+      "quantity": 6
     },
     "senate": {
-      "quantity": 3
+      "quantity": 8
     },
     "partyRangeStats": {
       "counts": {
         "1": 0,
         "2": 0,
-        "3": 15,
+        "3": 22,
         "4": 0,
         "5": 0
       },
       "mostPopularRanges": [
         3
       ],
-      "mostPopularCount": 15,
-      "totalCountedOfficials": 15,
+      "mostPopularCount": 22,
+      "totalCountedOfficials": 22,
       "unaffiliatedCount": 0,
       "unmappedPartyCount": 0
     },
@@ -6673,15 +6673,15 @@
         "counts": {
           "1": 0,
           "2": 0,
-          "3": 13,
+          "3": 20,
           "4": 0,
           "5": 0
         },
         "mostPopularRanges": [
           3
         ],
-        "mostPopularCount": 13,
-        "totalCountedOfficials": 13,
+        "mostPopularCount": 20,
+        "totalCountedOfficials": 20,
         "unaffiliatedCount": 0,
         "unmappedPartyCount": 0
       }


### PR DESCRIPTION
### Motivation
- Bring the Kazakhstan 2026 dataset in line with an updated government roster and corrected party naming.
- Reflect new ministerial appointments and leadership roles in the legislature so downstream aggregations are accurate.
- Ensure global summary stats for `kz` match the revised roster counts.

### Description
- Replaced and renamed multiple entries in `data/kz/2026/data.json`, including minister changes (e.g., new `Minister of Foreign Affairs` and new `Deputy Prime Minister and Minister of Artificial Intelligence and Digital Development`) and updated minister/ministerial roles.
- Updated Mazhilis deputies by adding `Albert Rau` (Deputy Chairman) and `Daniya Espayeva` (Deputy Chairwoman), adjusted faction/leader roles, and replaced several deputy records with corrected names and roles.
- Expanded the Senate list by adding multiple senator records, adjusted `Deputy Chairman of the Senate` role placement, and corrected district fields for new entries.
- Standardized party metadata by renaming `KNP`'s Kazakh name to `Қазақстан Халық партиясы` while keeping the English name as `People's Party of Kazakhstan`.
- Updated aggregated counts in `data/world/2026/data.json` for the `kz` section to reflect the new roster: `deputies.quantity` -> `6`, `senate.quantity` -> `8`, and adjusted `partyRangeStats` totals from `15` to `22` and corresponding split values.

### Testing
- Ran JSON schema validation against the modified `data/kz/2026/data.json` and `data/world/2026/data.json`; validation passed.
- Executed the repository's automated data checks and aggregation tests (`make validate` / CI data checks); all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e58990088331bdcbee0987d41c6d)