### PR TITLE
fix: verify complete country coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,11 @@ Before committing or pushing data changes, run the repository verifier:
 python3 scripts/verify-data.py
 ```
 
-The command automatically discovers and validates every four-digit year under the
-country data directories. To validate only selected years, pass them explicitly,
-for example `python3 scripts/verify-data.py 2025 2026`.
+The command automatically discovers every four-digit year and verifies that every
+indexed country has that year, both required JSON files, valid JSON, and the
+required data fields. This prevents a missing country/year or an entirely missing
+file from being silently skipped. To validate only selected years, pass them
+explicitly, for example `python3 scripts/verify-data.py 2025 2026`.
 
 Pull requests and every branch push run the same validation in GitHub Actions. The
 workflow must be configured as a required status check in the repository's branch

--- a/scripts/verify-data.py
+++ b/scripts/verify-data.py
@@ -51,66 +51,80 @@ def find_years():
     )
 
 
-def verify_year(year):
-    issues = []
-    summary = defaultdict(int)
-
-    country_dirs = sorted(
+def find_country_dirs():
+    """Return every directory that represents a country dataset."""
+    return sorted(
         path
         for path in (ROOT / "data").iterdir()
         if path.is_dir() and len(path.name) == 2 and path.name.isalpha()
     )
 
-    for country_dir in country_dirs:
+
+def find_country_codes():
+    """Use the global index as a manifest so a deleted country is not skipped."""
+    country_codes = {path.name for path in find_country_dirs()}
+    try:
+        global_index = json.loads((ROOT / "data" / "index.json").read_text())
+    except (json.JSONDecodeError, OSError):
+        return sorted(country_codes)
+    if isinstance(global_index, dict):
+        country_codes.update(global_index)
+    return sorted(country_codes)
+
+
+def verify_year(year):
+    issues = []
+    summary = defaultdict(int)
+
+    country_codes = find_country_codes()
+    summary["countries_expected"] = len(country_codes)
+
+    for country in country_codes:
+        country_dir = ROOT / "data" / country
         year_dir = country_dir / str(year)
         if not year_dir.is_dir():
+            issues.append((country, year_dir, "missing year directory"))
+            summary["missing_year_directories"] += 1
             continue
 
-        country = country_dir.name
         summary["countries"] += 1
         data_path = year_dir / "data.json"
         data = read_json(data_path, country, issues, summary)
-        if data is None:
-            continue
-
-        if not isinstance(data, dict):
-            issues.append((country, data_path, "top-level JSON value should be an object"))
-            summary["invalid_data_format"] += 1
-            continue
-
-        econ_path = data_path.with_name("economics.json")
+        econ_path = year_dir / "economics.json"
         economics = read_json(econ_path, country, issues, summary)
 
-        for key in required_data_keys:
-            if key not in data:
-                issues.append((country, data_path, f"missing key `{key}`"))
-                summary[f"missing_data_{key}"] += 1
+        if data is not None and not isinstance(data, dict):
+            issues.append((country, data_path, "top-level JSON value should be an object"))
+            summary["invalid_data_format"] += 1
+        elif data is not None:
+            for key in required_data_keys:
+                if key not in data:
+                    issues.append((country, data_path, f"missing key `{key}`"))
+                    summary[f"missing_data_{key}"] += 1
 
-        for section in people_sections:
-            values = data.get(section)
-            if values is not None and not isinstance(values, list):
-                issues.append((country, data_path, f"`{section}` should be a list"))
-                summary["invalid_people_sections"] += 1
+            for section in people_sections:
+                values = data.get(section)
+                if values is not None and not isinstance(values, list):
+                    issues.append((country, data_path, f"`{section}` should be a list"))
+                    summary["invalid_people_sections"] += 1
 
-        if "parties" in data and not isinstance(data["parties"], dict):
-            issues.append((country, data_path, "`parties` should be an object"))
-            summary["invalid_parties"] += 1
+            if "parties" in data and not isinstance(data["parties"], dict):
+                issues.append((country, data_path, "`parties` should be an object"))
+                summary["invalid_parties"] += 1
 
-        if economics is None:
-            continue
-
-        if not isinstance(economics, dict):
+        if economics is not None and not isinstance(economics, dict):
             issues.append((country, econ_path, "top-level JSON value should be an object"))
             summary["invalid_economics_format"] += 1
-            continue
-
-        for key in required_econ_keys:
-            if key not in economics:
-                issues.append((country, econ_path, f"missing key `{key}`"))
-                summary[f"missing_econ_{key}"] += 1
+        elif economics is not None:
+            for key in required_econ_keys:
+                if key not in economics:
+                    issues.append((country, econ_path, f"missing key `{key}`"))
+                    summary[f"missing_econ_{key}"] += 1
 
         if (
-            "baseCurrency" in data
+            isinstance(data, dict)
+            and isinstance(economics, dict)
+            and "baseCurrency" in data
             and "baseCurrency" in economics
             and data["baseCurrency"] != economics["baseCurrency"]
         ):
@@ -125,10 +139,11 @@ def verify_year(year):
             summary["base_currency_mismatch"] += 1
 
     print(f"{year} dataset verification")
+    print(f"Countries expected: {summary['countries_expected']}")
     print(f"Countries scanned: {summary['countries']}")
     print(f"Issues found: {len(issues)}")
     for key in sorted(summary):
-        if key != "countries":
+        if key not in {"countries", "countries_expected"}:
             print(f"- {key}: {summary[key]}")
 
     if issues:


### PR DESCRIPTION
### Motivation

- The verifier previously only scanned present country directories and could silently skip countries removed from the tree, allowing missing country/year files to go unnoticed.
- We need the verifier to ensure every indexed country has the expected year directories and both required JSON files so data completeness is enforced.

### Description

- Added `find_country_dirs()` and `find_country_codes()` to detect country directories and use `data/index.json` as a manifest so deleted countries are still checked.  The functions live in `scripts/verify-data.py`.
- Updated `verify_year()` to iterate over the manifest country codes and to report missing year directories as issues (adds `missing_year_directories` to the summary).
- Changed validation to read and validate `data.json` and `economics.json` independently so one malformed/missing file no longer skips validation of the other, and added stricter type/key checks and a `Countries expected / Countries scanned` summary printout.
- Updated `CONTRIBUTING.md` to document that the verifier checks indexed countries and ensures both JSON files and required fields are present (example usage remains `python3 scripts/verify-data.py`).

### Testing

- Ran `python3 -m py_compile scripts/verify-data.py` and it succeeded with no syntax errors.
- Ran `python3 scripts/verify-data.py` and it verified `2025` and `2026`, printing `Countries expected: 194`, `Countries scanned: 194`, and `Issues found: 0` for both years.
- Simulated a missing year by temporarily removing one country year directory and ran `python3 scripts/verify-data.py 2026`, which exited with failure and reported the removed country as `missing year directory` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c7b76bdec8331bc98724602685eda)